### PR TITLE
fix(): Setup DNS config in resolv.conf

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,8 +23,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	nested "github.com/antonfisher/nested-logrus-formatter"
@@ -188,6 +190,7 @@ func main() {
 	// ********************************************************************************
 	// Initiate connections
 	// ********************************************************************************
+	initDnsConfig := false
 	for i := 0; i < len(rootConf.NetworkServices); i++ {
 		// Update network services configs
 		u := (*nsurl.NSURL)(&rootConf.NetworkServices[i])
@@ -211,7 +214,39 @@ func main() {
 		}
 
 		logger.Infof("successfully connected to %v. Response: %v", u.NetworkService(), resp)
+
+		// Initialize DNS config only if atleast one of the responses contain a DnsContext section
+		if resp.GetContext().GetDnsContext() != nil {
+			initDnsConfig = true
+		}
 	}
+
+	if initDnsConfig {
+		// Copy the original resolv.conf to the backup directory so that the cmd-nsc sidecar can
+		// read from the backup and initialize its data structures related to dns resolution.
+		storeResolvConfigFile := "/etc/nsm-dns-config/resolv.conf.restore"
+		originalResolvConfigFile := "/etc/resolv.conf"
+
+		originalResolvConf, err := ioutil.ReadFile(originalResolvConfigFile)
+	        if err != nil || len(originalResolvConf) == 0 {
+			logger.Fatalf("failed to read resolv.conf: %v", err.Error())
+	        }
+	        err = os.WriteFile(storeResolvConfigFile, originalResolvConf, os.ModePerm)
+		if err != nil {
+			logger.Fatalf("failed to write resolv.conf to backup: %v", err.Error())
+		}
+
+		// Overwrite the original resolv.conf and set the nameserver to the localhost address to
+		// redirect dns queries to the cmd-nsc sidecar.
+		var sb strings.Builder
+		_, _ = sb.WriteString("nameserver 127.0.0.1")
+		_, _ = sb.WriteRune('\n')
+		_, _ = sb.WriteString("options ndots:5")
+		err = ioutil.WriteFile(originalResolvConfigFile, []byte(sb.String()), os.ModePerm)
+                if err != nil {
+			logger.Fatalf("failed to write to original resolv.conf: %v", err.Error())
+		}
+        }
 }
 
 func setLogLevel(level string) {


### PR DESCRIPTION
Backed up the original resolv.conf and overwrote its contents to redirect dns queries to the cmd-nsc sidecar.
This was needed because istio-proxy that runs as one of the sidecars seems to read the resolv.conf during bootup and cache the config. Any subsequent change to the resolv.conf is not picked up by the proxy. So if the cmd-nsc sidecar takes time to boot up and modify the resolv.conf for all the other containers, the istio-proxy sidecar would have read the original resolv.conf and ignored the config written by cmd-nsc. This causes name resolution to fail in istio-proxy for the domains that are serviced by a custom dns server other than the default kube-dns.

Signed-off-by: Bharath Horatti <bharath@aveshasystems.com>